### PR TITLE
Input component

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,4 +1,5 @@
 import type { StorybookConfig } from '@storybook/web-components-vite';
+import path from 'node:path';
 
 const config: StorybookConfig = {
   stories: [
@@ -10,9 +11,16 @@ const config: StorybookConfig = {
     '@storybook/addon-links',
     '@storybook/addon-essentials'
   ],
+  core: {
+    builder: '@storybook/builder-vite', // 👈 The builder enabled here.
+  },
   framework: {
     name: '@storybook/web-components-vite',
-    options: {}
+    options: {
+      builder: {
+        viteConfigPath: path.resolve('./.storybook/vite.config.ts')
+      }
+    }
   },
   docs: {
     autodocs: true

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -1,5 +1,4 @@
 import type { StorybookConfig } from '@storybook/web-components-vite';
-import path from 'node:path';
 
 const config: StorybookConfig = {
   stories: [

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -11,16 +11,9 @@ const config: StorybookConfig = {
     '@storybook/addon-links',
     '@storybook/addon-essentials'
   ],
-  core: {
-    builder: '@storybook/builder-vite', // 👈 The builder enabled here.
-  },
   framework: {
     name: '@storybook/web-components-vite',
-    options: {
-      builder: {
-        viteConfigPath: path.resolve('./.storybook/vite.config.ts')
-      }
-    }
+    options: {}
   },
   docs: {
     autodocs: true

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,7 +1,13 @@
 import type { Preview } from '@storybook/web-components'
 
-import '../styles/diamond-ui.css';
+// Vite builder doesn't like the glob import in diamond-ui.css
+// importing the individual css files here instead.
+import 'modern-normalize/modern-normalize.css';
+import '../styles/tokens.css';
+import '../styles/base.css';
 import '../styles/themes.css';
+// @ts-ignore-next-line
+import.meta.glob('../components/**/*.css', { eager: true });
 
 const preview: Preview = {
   parameters: {

--- a/components/control/Button/Button.css
+++ b/components/control/Button/Button.css
@@ -68,14 +68,8 @@ diamond-button {
 
     svg {
       block-size: var(--diamond-button-icon-size);
-      fill: none;
-      filter: drop-shadow(var(--diamond-button-text-shadow));
-
       flex-shrink: 0;
       inline-size: var(--diamond-button-icon-size);
-      stroke: currentColor;
-      stroke-linecap: round;
-      stroke-linejoin: round;
     }
   }
 

--- a/components/control/Button/Button.stories.ts
+++ b/components/control/Button/Button.stories.ts
@@ -113,6 +113,7 @@ export const IconOnlyButton: StoryObj = {
             <svg
               viewBox="0 0 24 24"
               stroke="currentColor"
+              fill="none"
               width="24"
               height="24"
               aria-label="Send mail"
@@ -130,6 +131,7 @@ export const IconOnlyButton: StoryObj = {
             <svg
               viewBox="0 0 24 24"
               stroke="currentColor"
+              fill="none"
               width="24"
               height="24"
               aria-label="Send mail"

--- a/components/control/Input/Input.css
+++ b/components/control/Input/Input.css
@@ -1,0 +1,73 @@
+diamond-input {
+  --_background: var(--diamond-input-background);
+  --_border-color: var(--diamond-input-border-color);
+
+  background: var(--_background);
+  border: 1px solid var(--_border-color);
+  border-radius: var(--diamond-input-border-radius);
+  color: var(--diamond-input-color);
+  display: flex;
+  overflow: hidden;
+  position: relative;
+  transition:
+    border-color var(--diamond-transition),
+    background-color var(--diamond-transition);
+
+  &:hover,
+  &:focus-within {
+    --_border-color: var(--diamond-input-border-color-hover);
+  }
+
+  &:focus-within {
+    --_background: var(--diamond-input-background-focus);
+  }
+
+  &[state='valid'] {
+    --_border-color: var(--diamond-input-border-color-valid);
+  }
+
+  &[state='invalid'] {
+    --_border-color: var(--diamond-input-border-color-invalid);
+  }
+
+  &:has([disabled]) {
+    --_background: var(--diamond-input-background-disabled);
+    cursor: not-allowed;
+    opacity: 0.5;
+    pointer-events: none;
+  }
+
+  input {
+    appearance: none;
+    background: none;
+    border: 0 none;
+    color: inherit;
+    display: block;
+    line-height: var(--diamond-input-line-height);
+    min-height: var(--diamond-spacing-thumb);
+    padding: var(--diamond-input-padding);
+    width: 100%;
+
+    &:focus {
+      outline: none;
+    }
+  }
+
+  svg {
+    block-size: var(--diamond-input-icon-size);
+    flex-shrink: 0;
+    inline-size: var(--diamond-input-icon-size);
+  }
+
+  /* Prefix */
+  &:has(* + input) :first-child {
+    margin-right: calc(var(--diamond-input-padding-horizontal) / 2 * -1);
+    padding: 0 0 0 var(--diamond-input-padding-horizontal);
+  }
+
+  /* Suffix */
+  input + * {
+    margin-left: calc(var(--diamond-input-padding-horizontal) / 2 * -1);
+    padding: 0 var(--diamond-input-padding-horizontal) 0 0;
+  }
+}

--- a/components/control/Input/Input.stories.ts
+++ b/components/control/Input/Input.stories.ts
@@ -1,0 +1,97 @@
+import { StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+
+import './Input';
+import '../../composition/Grid/Grid';
+import '../../composition/Grid/GridItem';
+
+export default {
+  component: 'diamond-input',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Wraps an HTML input element to provide consistent styling and behavior.',
+      },
+    },
+  },
+  argTypes: {
+    state: {
+      control: {
+        type: 'select',
+      },
+      options: ['valid', 'invalid'],
+    },
+  },
+};
+
+export const Input: StoryObj = {
+  render: (args) => html`
+    <diamond-input state="${args.state}">
+      <input />
+    </diamond-input>
+  `,
+};
+
+export const InputStates: StoryObj = {
+  render: () => html`
+    <diamond-grid wrap="wrap">
+      <diamond-grid-item>
+        <diamond-input state="valid">
+          <input value="valid" />
+        </diamond-input>
+      </diamond-grid-item>
+      <diamond-grid-item>
+        <diamond-input state="invalid">
+          <input value="invalid" />
+        </diamond-input>
+      </diamond-grid-item>
+      <diamond-grid-item>
+        <diamond-input>
+          <input value="disabled" disabled />
+        </diamond-input>
+      </diamond-grid-item>
+    </diamond-grid>
+  `,
+};
+
+export const Affix: StoryObj = {
+  render: () => html`
+    <diamond-grid wrap="wrap">
+      <diamond-grid-item>
+        <diamond-input>
+          <svg
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            fill="none"
+            width="24"
+            height="24"
+            aria-label="Send mail"
+          >
+            <path
+              d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+            />
+          </svg>
+          <input value="prefix" />
+        </diamond-input>
+      </diamond-grid-item>
+      <diamond-grid-item>
+        <diamond-input>
+          <input value="suffix" />
+          <svg
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+            fill="none"
+            width="24"
+            height="24"
+            aria-label="Send mail"
+          >
+            <path
+              d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+            />
+          </svg>
+        </diamond-input>
+      </diamond-grid-item>
+    </diamond-grid>
+  `,
+};

--- a/components/control/Input/Input.ts
+++ b/components/control/Input/Input.ts
@@ -1,0 +1,19 @@
+export {};
+
+export interface InputAttributes {
+  state?: 'valid' | 'invalid';
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'diamond-input': InputAttributes;
+  }
+}
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'diamond-input': InputAttributes & React.HTMLAttributes<HTMLElement>;
+    }
+  }
+}

--- a/styles/tokens/color.css
+++ b/styles/tokens/color.css
@@ -13,4 +13,8 @@
   --diamond-color-grey-900: #1a1a1a;
 
   --diamond-color-black: #000;
+
+  --diamond-color-green-100: #219653;
+
+  --diamond-color-red-100: #eb5757;
 }

--- a/styles/tokens/input.css
+++ b/styles/tokens/input.css
@@ -1,11 +1,15 @@
 :root {
-  --diamond-input-background: var(--diamond-color-white);
-  --diamond-input-background-focus: var(--diamond-color-white);
-  --diamond-input-border: var(--diamond-color-black);
-  --diamond-input-border-hover: var(--diamond-color-black);
-  --diamond-input-border-radius: var(--diamond-border-radius);
+  --diamond-input-background: var(--diamond-theme-background);
+  --diamond-input-background-focus: var(--diamond-theme-background);
+  --diamond-input-background-disabled: var(--diamond-theme-background-muted);
 
-  --diamond-input-color: var(--diamond-color-black);
+  --diamond-input-border-radius: var(--diamond-border-radius);
+  --diamond-input-border-color: var(--diamond-theme-border-color);
+  --diamond-input-border-color-hover: var(--diamond-theme-border-color-hover);
+  --diamond-input-border-color-valid: var(--diamond-color-green-100);
+  --diamond-input-border-color-invalid: var(--diamond-color-red-100);
+
+  --diamond-input-color: var(--diamond-theme-color);
 
   --diamond-input-checked: var(--diamond-color-black);
   --diamond-input-checkradio-border-radius: var(--diamond-border-radius-xs);
@@ -14,4 +18,6 @@
   --diamond-input-padding-horizontal: var(--diamond-spacing);
   --diamond-input-padding: var(--diamond-input-padding-vertical)
     var(--diamond-input-padding-horizontal);
+
+  --diamond-input-line-height: var(--diamond-font-line-height);
 }

--- a/styles/tokens/input.css
+++ b/styles/tokens/input.css
@@ -20,4 +20,6 @@
     var(--diamond-input-padding-horizontal);
 
   --diamond-input-line-height: var(--diamond-font-line-height);
+
+  --diamond-input-icon-size: 2ch;
 }


### PR DESCRIPTION
Wraps around the native `<input>` to provide styles and states.

This is kept pretty barebones at the moment

- Uses ninja input pattern to hide the input and apply states to the outer border instead
- Focus handled via focus within
- Disabled handled using :has selector
- Default colors use theme vars to be unopinionated
- State prop for valid/invalid, I considered using :has(:valid) but I think we still rarely use HTML validation(?)
- Affix is covered without any props but it does assume only 3 elements are inside the diamond-input
- Handling SVG under button and icon is the same, not sure about this yet, I think it's okay until we get into more depth with the icon component

https://github.com/etchteam/diamond-ui/assets/5038459/7f483257-1b7b-4984-a5eb-f709cf662c10

