### PR TITLE
Fix dts output path

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "rollup": "4.9.4",
         "rollup-plugin-copy": "^3.5.0",
         "rollup-plugin-delete": "^2.0.0",
+        "rollup-plugin-dts": "^6.1.0",
         "rollup-plugin-postcss": "^4.0.2",
         "semantic-release": "^23.0.0",
         "storybook": "7.6.7",
@@ -20728,6 +20729,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/rollup-plugin-dts": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.1.0.tgz",
+      "integrity": "sha512-ijSCPICkRMDKDLBK9torss07+8dl9UpY9z1N/zTeA1cIqdzMlpkV3MOOC7zukyvQfDyxa1s3Dl2+DeiP/G6DOw==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.30.4"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Swatinem"
+      },
+      "optionalDependencies": {
+        "@babel/code-frame": "^7.22.13"
+      },
+      "peerDependencies": {
+        "rollup": "^3.29.4 || ^4",
+        "typescript": "^4.5 || ^5.0"
       }
     },
     "node_modules/rollup-plugin-postcss": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "rollup": "4.9.4",
     "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-delete": "^2.0.0",
+    "rollup-plugin-dts": "^6.1.0",
     "rollup-plugin-postcss": "^4.0.2",
     "semantic-release": "^23.0.0",
     "storybook": "7.6.7",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,7 +13,7 @@ import postcss from 'rollup-plugin-postcss';
 const config = defineConfig([
   {
     plugins: [
-      del({ targets: 'dist/*' }),
+      del({ targets: 'dist/**' }),
       typescript(),
       copy({
         targets: [{ src: 'package.json', dest: 'dist' }],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "experimentalDecorators": true,
     "moduleResolution": "node",
     "strict": true,
-    "outDir": "./dist",
     "allowSyntheticDefaultImports": true
   },
   "exclude": [


### PR DESCRIPTION
All the component types are output in `/component/*`

But the component files are in `/control/*` `/composition/*` `/content/*`

Annoyingly, the ts plugin doesn't seem to take notice of the output dir where we've got multiple inputs.

The dts plugin does though, so it now runs after the initial ts bundling is done.