### PR TITLE
feat: add key to jsx type

### DIFF
--- a/components/canvas/Card/Card.ts
+++ b/components/canvas/Card/Card.ts
@@ -1,3 +1,5 @@
+import { JSXCustomElement } from '../../../types/jsx-custom-element';
+
 export interface CardAttributes {
   border?: boolean;
   shadow?: boolean;
@@ -15,8 +17,7 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'diamond-card': CardAttributes &
-        React.HTMLAttributes<HTMLElement> & { key?: string };
+      'diamond-card': CardAttributes & JSXCustomElement;
     }
   }
 }

--- a/components/composition/Grid/Grid.ts
+++ b/components/composition/Grid/Grid.ts
@@ -1,3 +1,5 @@
+import { JSXCustomElement } from '../../../types/jsx-custom-element';
+
 export interface GridAttributes {
   wrap?: 'wrap' | 'nowrap' | 'wrap-reverse';
   inline?: boolean;
@@ -22,7 +24,7 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'diamond-grid': GridAttributes & React.HTMLAttributes<HTMLElement> & { key?: string };
+      'diamond-grid': GridAttributes & JSXCustomElement;
     }
   }
 }

--- a/components/composition/Grid/GridItem.ts
+++ b/components/composition/Grid/GridItem.ts
@@ -1,3 +1,5 @@
+import { JSXCustomElement } from '../../../types/jsx-custom-element';
+
 type Column =
   | 'auto'
   | '1'
@@ -36,8 +38,7 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'diamond-grid-item': GridItemAttributes &
-        React.HTMLAttributes<HTMLElement> & { key?: string };
+      'diamond-grid-item': GridItemAttributes & JSXCustomElement;
     }
   }
 }

--- a/components/composition/Wrap/Wrap.ts
+++ b/components/composition/Wrap/Wrap.ts
@@ -1,3 +1,5 @@
+import { JSXCustomElement } from '../../../types/jsx-custom-element';
+
 export interface WrapAttributes {
   size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'xxl' | 'xxxl' | 'xxxxl';
   gutter: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | 'none';
@@ -12,8 +14,7 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'diamond-wrap': WrapAttributes &
-        React.HTMLAttributes<HTMLElement> & { key?: string } & { key?: string };
+      'diamond-wrap': WrapAttributes & JSXCustomElement;
     }
   }
 }

--- a/components/content/Img/Img.ts
+++ b/components/content/Img/Img.ts
@@ -1,6 +1,8 @@
 import { LitElement, css, html } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
+import { JSXCustomElement } from '../../../types/jsx-custom-element';
+
 @customElement('diamond-img')
 export class Img extends LitElement {
   @property({ reflect: true }) readonly fit?: 'contain' | 'cover' | 'fill';
@@ -42,7 +44,7 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'diamond-img': Img & React.HTMLAttributes<HTMLElement> & { key?: string };
+      'diamond-img': Img & JSXCustomElement;
     }
   }
 }

--- a/components/control/Button/Button.ts
+++ b/components/control/Button/Button.ts
@@ -1,3 +1,5 @@
+import { JSXCustomElement } from '../../../types/jsx-custom-element';
+
 export interface ButtonAttributes {
   size?: 'sm' | 'md' | 'lg';
   variant?: 'primary' | 'secondary' | 'text';
@@ -13,7 +15,7 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'diamond-button': ButtonAttributes & React.HTMLAttributes<HTMLElement> & { key?: string };
+      'diamond-button': ButtonAttributes & JSXCustomElement;
     }
   }
 }

--- a/components/control/Input/Input.ts
+++ b/components/control/Input/Input.ts
@@ -1,3 +1,5 @@
+import { JSXCustomElement } from '../../../types/jsx-custom-element';
+
 export interface InputAttributes {
   state?: 'valid' | 'invalid';
 }
@@ -11,7 +13,7 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'diamond-input': InputAttributes & React.HTMLAttributes<HTMLElement> & { key?: string };
+      'diamond-input': InputAttributes & JSXCustomElement;
     }
   }
 }

--- a/types/jsx-custom-element.ts
+++ b/types/jsx-custom-element.ts
@@ -1,0 +1,3 @@
+export type JSXCustomElement = React.HTMLAttributes<HTMLElement> & {
+  key?: string;
+};


### PR DESCRIPTION
Add `key` to the JSX type for components.
I've dug through the React types modules and I can't find anything that includes `key`. I think the types in JSX.IntrinsicElements have them, but that namespace is private so you have to import it from the react package and I don't want to do that. Simplest solution is just add key.

Created a type for this if we manage to optimise it further in future.