### PR TITLE
feat: set default button text shadow to none

### DIFF
--- a/styles/tokens/button.css
+++ b/styles/tokens/button.css
@@ -1,6 +1,6 @@
 :root {
   --diamond-button-border-radius: var(--diamond-border-radius);
-  --diamond-button-text-shadow: 0 1px 0 var(--diamond-color-grey-100);
+  --diamond-button-text-shadow: none;
   --diamond-button-file-background: var(--diamond-color-grey-100);
   --diamond-button-padding-inline: var(--diamond-spacing);
   --diamond-button-padding-block: var(--diamond-spacing-sm);


### PR DESCRIPTION
Removes `text-shadow` from `Button` component by setting `--diamond-button-text-shadow: none`.

Retains the CSS variable so that the text shadow on buttons can still be customised if needed.

