### PR TITLE
feat/ETCH-465 add none option to spacing

### DIFF
--- a/components/composition/Spacing/Spacing.css
+++ b/components/composition/Spacing/Spacing.css
@@ -1,4 +1,7 @@
 /* top */
+.diamond-spacing-top-none {
+  margin-top: 0;
+}
 
 .diamond-spacing-top-xs {
   margin-top: var(--diamond-spacing-xs);
@@ -33,6 +36,9 @@
 }
 
 /* bottom */
+.diamond-spacing-bottom-none {
+  margin-bottom: 0;
+}
 
 .diamond-spacing-bottom-xs {
   margin-bottom: var(--diamond-spacing-xs);

--- a/components/composition/Spacing/Spacing.stories.ts
+++ b/components/composition/Spacing/Spacing.stories.ts
@@ -20,7 +20,17 @@ export default {
   argTypes: {
     size: {
       control: { type: 'select' },
-      options: ['xs', 'sm', 'md', 'lg', 'xl', 'fluid', 'fluid-sm', 'fluid-lg'],
+      options: [
+        'none',
+        'xs',
+        'sm',
+        'md',
+        'lg',
+        'xl',
+        'fluid',
+        'fluid-sm',
+        'fluid-lg',
+      ],
     },
   },
 };


### PR DESCRIPTION
While building this it occurred to me this is fairly pointless, why would we want none on the spacing component if we could just choose not to use it?