### PR TITLE
fix: stop label styles leaking into storybook controls

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -6,6 +6,7 @@ import 'modern-normalize/modern-normalize.css';
 import '../styles/tokens.css';
 import '../styles/base.css';
 import '../styles/themes.css';
+import './styles.css'; // Storybook style overrides
 // @ts-ignore-next-line
 import.meta.glob('../components/**/*.css', { eager: true });
 

--- a/.storybook/styles.css
+++ b/.storybook/styles.css
@@ -1,0 +1,3 @@
+.docblock-argstable-body label {
+  min-height: auto;
+}


### PR DESCRIPTION
Stop label min height affecting storybook controls