### PR TITLE
Omit size prop from jsx element

### DIFF
--- a/components/canvas/Card/Card.ts
+++ b/components/canvas/Card/Card.ts
@@ -26,7 +26,7 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'diamond-card': CardAttributes & JSXCustomElement;
+      'diamond-card': JSXCustomElement<CardAttributes>;
     }
   }
 }

--- a/components/canvas/Section/Section.ts
+++ b/components/canvas/Section/Section.ts
@@ -22,7 +22,7 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'diamond-section': SectionAttributes & JSXCustomElement;
+      'diamond-section': JSXCustomElement<SectionAttributes>;
     }
   }
 }

--- a/components/composition/App/App.ts
+++ b/components/composition/App/App.ts
@@ -35,7 +35,7 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'diamond-app': AppAttributes & JSXCustomElement;
+      'diamond-app': JSXCustomElement<AppAttributes>;
     }
   }
 }

--- a/components/composition/Enter/Enter.ts
+++ b/components/composition/Enter/Enter.ts
@@ -70,7 +70,7 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'diamond-enter': EnterAttributes & JSXCustomElement;
+      'diamond-enter': JSXCustomElement<EnterAttributes>;
     }
   }
 }

--- a/components/composition/FormGroup/FormGroup.ts
+++ b/components/composition/FormGroup/FormGroup.ts
@@ -13,7 +13,7 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'diamond-form-group': FormGroupAttributes & JSXCustomElement;
+      'diamond-form-group': JSXCustomElement<FormGroupAttributes>;
     }
   }
 }

--- a/components/composition/Grid/Grid.ts
+++ b/components/composition/Grid/Grid.ts
@@ -24,7 +24,7 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'diamond-grid': GridAttributes & JSXCustomElement;
+      'diamond-grid': JSXCustomElement<GridAttributes>;
     }
   }
 }

--- a/components/composition/Grid/GridItem.ts
+++ b/components/composition/Grid/GridItem.ts
@@ -42,7 +42,7 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'diamond-grid-item': GridItemAttributes & JSXCustomElement;
+      'diamond-grid-item': JSXCustomElement<GridItemAttributes>;
     }
   }
 }

--- a/components/composition/Wrap/Wrap.ts
+++ b/components/composition/Wrap/Wrap.ts
@@ -14,7 +14,7 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'diamond-wrap': WrapAttributes & JSXCustomElement;
+      'diamond-wrap': JSXCustomElement<WrapAttributes>;
     }
   }
 }

--- a/components/content/Img/Img.ts
+++ b/components/content/Img/Img.ts
@@ -48,7 +48,7 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'diamond-img': ImgAttributes & JSXCustomElement;
+      'diamond-img': JSXCustomElement<ImgAttributes>;
     }
   }
 }

--- a/components/control/Button/Button.ts
+++ b/components/control/Button/Button.ts
@@ -15,7 +15,7 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'diamond-button': ButtonAttributes & JSXCustomElement;
+      'diamond-button': JSXCustomElement<ButtonAttributes>;
     }
   }
 }

--- a/components/control/Input/Input.ts
+++ b/components/control/Input/Input.ts
@@ -13,7 +13,7 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'diamond-input': InputAttributes & JSXCustomElement;
+      'diamond-input': JSXCustomElement<InputAttributes>;
     }
   }
 }

--- a/components/control/RadioCheckbox/RadioCheckbox.ts
+++ b/components/control/RadioCheckbox/RadioCheckbox.ts
@@ -45,7 +45,7 @@ declare global {
 declare module 'react' {
   namespace JSX {
     interface IntrinsicElements {
-      'diamond-radio-checkbox': RadioCheckboxAttributes & JSXCustomElement;
+      'diamond-radio-checkbox': JSXCustomElement<RadioCheckboxAttributes>;
     }
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "allowSyntheticDefaultImports": true
   },
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "dist"
   ]
 }

--- a/types/jsx-custom-element.ts
+++ b/types/jsx-custom-element.ts
@@ -1,4 +1,7 @@
-export type JSXCustomElement = React.HTMLAttributes<HTMLElement> & {
-  key?: string | number;
-  class?: string;
-};
+export type JSXCustomElement<T = object> = T &
+  Omit<React.HTMLAttributes<HTMLElement>, 'size'> & {
+    key?: string | number;
+    class?: string;
+    slot?: string;
+    shadowRoot?: ShadowRoot;
+  };


### PR DESCRIPTION
Omits the size prop that JSX element adds which ovewrites the size prop on diamond custom elements

Adds a type generic to clean up the type and some missing properties.

Fixes typescript taking types from the built dist d.ts files