### PR TITLE
Input width overflow

### DIFF
--- a/components/control/Input/Input.css
+++ b/components/control/Input/Input.css
@@ -7,6 +7,7 @@ diamond-input {
   border-radius: var(--diamond-input-border-radius);
   color: var(--diamond-input-color);
   display: flex;
+  min-width: 0;
   position: relative;
   transition:
     border-color var(--diamond-transition),
@@ -53,6 +54,7 @@ diamond-input {
     font-size: var(--diamond-input-font-size);
     line-height: var(--diamond-input-line-height);
     padding: var(--diamond-input-padding);
+    width: 100%;
 
     &:focus {
       outline: none;


### PR DESCRIPTION
![Screenshot 2024-04-26 at 14 40 42](https://github.com/etchteam/diamond-ui/assets/5038459/14a225ef-4fbc-4232-acca-91e1989d5ed8)

- [Min-width fix needed](https://defensivecss.dev/tip/flexbox-min-content-size/) in some browsers caused by diamond-input being display: flex 
- Applying only min-width can still leave the underlying input overflowing so width 100% has been applied