### PR TITLE
Sub-pixel radio and checkbox rendering issues

### DIFF
--- a/components/control/RadioCheckbox/RadioCheckbox.css
+++ b/components/control/RadioCheckbox/RadioCheckbox.css
@@ -72,7 +72,7 @@ diamond-radio-checkbox {
 
   &::part(indicator) {
     align-items: center;
-    aspect-ratio: 1 / 1;
+    aspect-ratio: 1;
     background: var(--_background);
     border: 1px solid var(--_border-color);
     border-radius: var(--_border-radius);
@@ -91,15 +91,13 @@ diamond-radio-checkbox {
   }
 
   &::part(indicator)::before {
-    aspect-ratio: 1 / 1;
+    aspect-ratio: 1;
     background-color: var(--_border-color);
     border-radius: var(--_inner-border-radius);
     content: '';
-    left: 50%;
     opacity: 0;
     position: absolute;
-    top: 50%;
-    transform: translate(-50%, -50%) scale(0.5);
+    transform: scale(0.5);
     transition:
       background-color var(--diamond-transition),
       opacity var(--diamond-transition),
@@ -123,7 +121,7 @@ diamond-radio-checkbox {
 
     &::part(indicator)::before {
       opacity: 1;
-      transform: translate(-50%, -50%) scale(1);
+      transform: scale(1);
     }
 
     svg,


### PR DESCRIPTION
**Problem**
On small screen or when the parent text size is modified, we get alignment issues with checkboxes and radios. 

**Diagnosis**
Changing to an odd em value can throw the alignment 1px off

**Solution**
Allow the browser to do the calculation using Flexbox

**Testing**
The attached video shows before and after changes applied.

**Notes**

- The aspect ratio has nothing to do with the fix, but it's cleaning up a couple of unnecessary extra chars
- Keeping the position as absolute is necessary for the checkboxes, I haven't used the quirk before so I was a bit concerned about the interplay between flexbox alignment and absolute positioning, [apparently if no there's top/right/bottom/left properties, then flexbox alignment will still apply to it](https://css-tricks.com/flexbox-and-absolute-positioning/#:~:text=Chen%20Hui%20Jing%20notes%20that,will%20still%20apply%20to%20it.) absolute positioning also gets a [mention in the spec](https://drafts.csswg.org/css-align/#align-self-property).

https://github.com/etchteam/diamond-ui/assets/5038459/bf99760c-a865-4b33-8ebd-993a7e4ea6c5
