### PR TITLE
Feature/etch 545 better spacing docs

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -16,6 +16,7 @@ module.exports = {
           'td',
           'color',
           'nowrap',
+          'center',
         ],
       },
     ],

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,7 +6,17 @@ module.exports = {
       'warn',
       {
         lang: 'en_GB',
-        skipWords: ['namespace', 'etchteam', 'plugins', 'lang'],
+        skipWords: [
+          'namespace',
+          'etchteam',
+          'plugins',
+          'lang',
+          'var',
+          'th',
+          'td',
+          'color',
+          'nowrap',
+        ],
       },
     ],
     '@typescript-eslint/no-namespace': [

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,7 +1,14 @@
 module.exports = {
-  plugins: ['lit-a11y'],
+  plugins: ['lit-a11y', 'spellcheck'],
   extends: ['@etchteam', 'plugin:lit-a11y/recommended'],
   rules: {
+    'spellcheck/spell-checker': [
+      'warn',
+      {
+        lang: 'en_GB',
+        skipWords: ['namespace', 'etchteam', 'plugins', 'lang'],
+      },
+    ],
     '@typescript-eslint/no-namespace': [
       'error',
       {

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -8,6 +8,9 @@ import '../styles/base.css';
 import '../styles/themes.css';
 import '../styles/docs/docs.css';
 import './styles.css'; // Storybook style overrides
+
+import '../docs/components/TokenTable';
+
 // @ts-ignore-next-line
 import.meta.glob('../components/**/*.css', { eager: true });
 

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -9,6 +9,7 @@ import '../styles/themes.css';
 import '../styles/docs/docs.css';
 import './styles.css'; // Storybook style overrides
 
+import '../docs/components/Spacing';
 import '../docs/components/TokenTable';
 
 // @ts-ignore-next-line

--- a/.storybook/styles.css
+++ b/.storybook/styles.css
@@ -3,9 +3,10 @@
 }
 
 docs-placeholder {
-  border: dotted 1px var(--diamond-theme-border-color-hover);
+  background: var(--diamond-color-grey-50);
+  border: dotted 1px var(--diamond-theme-border-color);
   border-radius: var(--diamond-radius-sm);
   display: block;
   padding: var(--diamond-spacing-lg);
-  text-align: center;
+  text-align: left;
 }

--- a/components/canvas/Card/Card.stories.ts
+++ b/components/canvas/Card/Card.stories.ts
@@ -44,7 +44,7 @@ export const Card: StoryObj = {
       class="diamond-theme-${theme}"
     >
       <docs-placeholder>
-        <h2>Placeholder content</h2>
+        <h3>Placeholder content</h3>
         <p>
           The slot can contain anything, the card component acts as a simple
           wrapper with optional props for styling the card itself.
@@ -105,17 +105,16 @@ export const ImageCard: StoryObj = {
   render: () => html`
     <diamond-wrap size="sm">
       <diamond-card border radius shadow class="diamond-theme-light">
-        <diamond-img block responsive>
+        <diamond-img block responsive class="diamond-spacing-bottom-md">
           <img
             src="https://placehold.co/400x300"
             alt="Placeholder"
             width="400"
             height="300"
-            class="diamond-spacing-bottom-md"
           />
         </diamond-img>
         <h3>Card title</h3>
-        <p>
+        <p class="diamond-spacing-bottom-lg">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua.
         </p>

--- a/components/composition/Spacing/Spacing.stories.ts
+++ b/components/composition/Spacing/Spacing.stories.ts
@@ -4,8 +4,15 @@ import { html } from 'lit';
 const description = `
 Diamond spacing is a set of utility classes that can be added to any component or element.
 
+The spacing class name format is \`diamond-spacing-{direction}-{size}\`, e.g. \`diamond-spacing-bottom-sm\`.
+
 Spacing tweaks are one of the most common reasons for introducing page level CSS, which is
 a slippery slope to a bloated CSS file. Diamond spacing reduces or eliminates these tweaks.
+
+Individual components should not create spacing around themselves. Instead, they should use
+spacing classes to create the desired layout.
+
+It is generally recommended to use **bottom spacing** and **no top spacing** to prevent [margin collapse](https://www.joshwcomeau.com/css/rules-of-margin-collapse/).
 `;
 
 export default {

--- a/docs/Theming.mdx
+++ b/docs/Theming.mdx
@@ -11,7 +11,7 @@ Diamond UI supports component theming but provides no production-ready themes ou
 
 All themes are based on a core set of variables.
 
-<Source code={theme} language='css' />
+<docs-token-table code={theme}></docs-token-table>
 
 These can be overridden by setting the `:root` CSS variables to create a base theme and creating theme classes that can wrap components or groups of components.
 
@@ -23,7 +23,7 @@ Diamond UI optionally includes an example set of 3 basic themes: light, medium a
 
 Components that support theming will apply the base theme tokens, such as setting the background to `--diamond-theme-background`.
 
-<Source code={themes} language='css' />
+<docs-token-table code={themes}></docs-token-table>
 
 ### Cards using demo themes
 

--- a/docs/components/Spacing.ts
+++ b/docs/components/Spacing.ts
@@ -1,0 +1,97 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import { JSXCustomElement } from '../../types/jsx-custom-element';
+
+export interface SpacingAttributes {
+  size: string;
+}
+
+@customElement('docs-spacing')
+export class TokenTable extends LitElement {
+  @property({ reflect: true }) size: string = 'md';
+  @property({ reflect: true }) direction: 'top' | 'bottom' = 'bottom';
+  @property({ reflect: true }) alignment: 'center' | 'left' = 'center';
+
+  static readonly styles = css`
+    :host {
+      display: block;
+      color: var(--diamond-color-red-100);
+      font-size: var(--diamond-font-size-xs);
+      height: 0;
+      position: relative;
+    }
+
+    :host([direction='top']) .docs-spacing__content {
+      transform: translateY(-100%);
+    }
+
+    :host([alignment='left']) .docs-spacing__content {
+      justify-content: flex-start;
+      padding-left: var(--diamond-spacing-md);
+    }
+
+    .docs-spacing__content {
+      align-items: center;
+      display: flex;
+      gap: var(--diamond-spacing-xs);
+      height: var(--docs-spacing-height);
+      justify-content: center;
+      padding-left: var(--diamond-spacing-md);
+    }
+
+    .docs-spacing__border {
+      border-bottom: 1px solid var(--diamond-color-red-100);
+      border-top: 1px solid var(--diamond-color-red-100);
+      height: 100%;
+      position: relative;
+      width: 7px;
+    }
+
+    .docs-spacing__border::before {
+      background-color: var(--diamond-color-red-100);
+      content: '';
+      display: block;
+      height: 100%;
+      left: 50%;
+      position: absolute;
+      width: 1px;
+    }
+
+    .docs-spacing__text {
+      max-width: 0;
+      white-space: nowrap;
+      width: 0;
+    }
+  `;
+
+  render() {
+    const { size } = this;
+
+    return html`
+      <style>
+        :host {
+          --docs-spacing-height: var(--diamond-spacing-${size});
+        }
+      </style>
+      <div class="docs-spacing__content">
+        <div class="docs-spacing__border"></div>
+        <div class="docs-spacing__text">${size}</div>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'docs-spacing': SpacingAttributes;
+  }
+}
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'docs-spacing': JSXCustomElement<SpacingAttributes>;
+    }
+  }
+}

--- a/docs/components/TokenTable.ts
+++ b/docs/components/TokenTable.ts
@@ -1,7 +1,7 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
-import { JSXCustomElement } from '../../../types/jsx-custom-element';
+import { JSXCustomElement } from '../../types/jsx-custom-element';
 
 export interface TokenTableAttributes {
   code: string;

--- a/docs/components/TokenTable.ts
+++ b/docs/components/TokenTable.ts
@@ -1,0 +1,101 @@
+import { LitElement, html, css } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+import { JSXCustomElement } from '../../../types/jsx-custom-element';
+
+export interface TokenTableAttributes {
+  code: string;
+}
+
+@customElement('docs-token-table')
+export class TokenTable extends LitElement {
+  @property({ reflect: true }) code: string;
+
+  static readonly styles = css`
+    :host {
+      display: block;
+    }
+
+    table {
+      border: var(--diamond-border);
+      border-collapse: collapse;
+      margin-block: var(--diamond-spacing-lg);
+      text-align: left;
+      width: 100%;
+    }
+
+    th,
+    td {
+      border: var(--diamond-border);
+      font-size: var(--diamond-font-size-sm);
+      padding: var(--diamond-spacing-sm);
+    }
+
+    th {
+      background-color: var(--diamond-color-grey-50);
+    }
+
+    code {
+      background-color: var(--diamond-color-grey-50);
+      border: var(--diamond-border);
+      border-radius: var(--diamond-radius-sm);
+      color: var(--diamond-color-grey-700);
+      font-size: var(--diamond-font-size-sm);
+      line-height: 1;
+      padding: var(--diamond-spacing-xs) var(--diamond-spacing-sm);
+      white-space: nowrap;
+    }
+  `;
+
+  render() {
+    const { code } = this;
+
+    // Find all the tokens in the code
+    const splitTokens = code.split(';');
+    const parsedTokens = splitTokens
+      .map((token) => /--diamond-([a-z]+)-([a-z-]+): (.+)/.exec(token))
+      .filter(Boolean)
+      .map((token) => ({
+        group: token?.[1],
+        name: token?.[2],
+        value: token?.[3],
+      }));
+
+    return html`
+      <table>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Token</th>
+            <th>Default value</th>
+          </tr>
+        </thead>
+        <tbody>
+          ${parsedTokens.map(
+            (token) => html`
+              <tr>
+                <td>${token?.name}</td>
+                <td><code>--diamond-${token?.group}-${token?.name}</code></td>
+                <td>${token?.value}</td>
+              </tr>
+            `,
+          )}
+        </tbody>
+      </table>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'docs-token-table': TokenTableAttributes;
+  }
+}
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'docs-token-table': JSXCustomElement<TokenTableAttributes>;
+    }
+  }
+}

--- a/docs/tokens/Border.mdx
+++ b/docs/tokens/Border.mdx
@@ -8,6 +8,6 @@ import * as ThemingStories from '../recipes/Theming.stories.ts'
 
 Diamond borders inherit the colour from the theme style.
 
-<Source code={code} language='css' />
+<docs-token-table code={code}></docs-token-table>
 
 <Canvas of={ThemingStories.Theming} />

--- a/docs/tokens/Button.mdx
+++ b/docs/tokens/Button.mdx
@@ -6,7 +6,7 @@ import * as ButtonStories from '../../components/control/Button/Button.stories.t
 
 # Button
 
-<Source code={code} language='css' />
+<docs-token-table code={code}></docs-token-table>
 
 <Canvas of={ButtonStories.Button} />
 

--- a/docs/tokens/Color.mdx
+++ b/docs/tokens/Color.mdx
@@ -7,7 +7,7 @@ import code from '../../styles/tokens/color.css?inline';
 
 Diamond components are unbranded. Because of this, the colour palette is very limited to provide the minimum functionality and allow for easier white labelling.
 
-<Source code={code} language='css' />
+<docs-token-table code={code}></docs-token-table>
 
 <diamond-grid class="diamond-spacing-bottom-lg" wrap="wrap">
   {['white', 'black'].map((color) => (

--- a/docs/tokens/Font.mdx
+++ b/docs/tokens/Font.mdx
@@ -8,7 +8,7 @@ import * as TypographyStories from '../recipes/Typography.stories.ts'
 
 Diamond has font sizes from xs to xxxl and h1 to h4. If you end up past h4, that's often a bad sign.
 
-<Source code={code} language='css' />
+<docs-token-table code={code}></docs-token-table>
 
 <Canvas of={TypographyStories.Headings} />
 

--- a/docs/tokens/Input.mdx
+++ b/docs/tokens/Input.mdx
@@ -8,7 +8,7 @@ import * as RadioCheckboxStories from '../../components/control/RadioCheckbox/Ra
 
 # Input
 
-<Source code={code} language='css' />
+<docs-token-table code={code}></docs-token-table>
 
 <Canvas of={FormGroupStories.FormGroup} />
 

--- a/docs/tokens/Label.mdx
+++ b/docs/tokens/Label.mdx
@@ -6,6 +6,6 @@ import * as FormGroupStories from '../../components/composition/FormGroup/FormGr
 
 # Label
 
-<Source code={code} language='css' />
+<docs-token-table code={code}></docs-token-table>
 
 <Canvas of={FormGroupStories.FormGroup} />

--- a/docs/tokens/Radius.mdx
+++ b/docs/tokens/Radius.mdx
@@ -7,7 +7,7 @@ import code from '../../styles/tokens/radius.css?inline';
 
 There are 4 radii from xs to lg.
 
-<Source code={code} language='css' />
+<docs-token-table code={code}></docs-token-table>
 
 <diamond-grid>
   <diamond-grid-item small-mobile="6" tablet="3">

--- a/docs/tokens/Shadow.mdx
+++ b/docs/tokens/Shadow.mdx
@@ -7,7 +7,7 @@ import code from '../../styles/tokens/shadow.css?inline';
 
 Shadows can be used when an element sits on top of other elements, like a fixed nav bar.
 
-<Source code={code} language='css' />
+<docs-token-table code={code}></docs-token-table>
 
 <diamond-wrap size="xs">
   <diamond-card shadow radius border>

--- a/docs/tokens/Spacing.mdx
+++ b/docs/tokens/Spacing.mdx
@@ -7,27 +7,76 @@ import code from '../../styles/tokens/spacing.css?inline';
 
 The spacing tokens define a set of sizes used for creating space around or within elements, like margins and padding.
 
-Generally, md is good for padding components and horizontal spacing between elements or vertical between similar elements. The default spacing `--diamond-spacing` is an alias of `--diamond-spacing-md`.
-
-Use lg for spacing between larger sections of content or for emphasis, such as before a button.
-
-xl and fluid are great for spacing around large sections of content, such as page sections.
+Spacing can be applied standalone to HTML elements or components using the [spacing utility classes](?path=/docs/composition-spacing--docs).
 
 <docs-token-table code={code}></docs-token-table>
 
 ## Fixed spacing between elements
 
 {['xs', 'sm', 'md', 'lg', 'xl'].map((size) => (
-  <docs-wrap class={`diamond-spacing-bottom-${size}`}>{size}</docs-wrap>
+  <>
+    <docs-wrap></docs-wrap>
+    <docs-spacing size={size} class={`diamond-spacing-bottom-${size}`}></docs-spacing>
+  </>
 ))}
 
-<docs-wrap class="diamond-spacing-bottom-lg">End element for demo purposes</docs-wrap>
+<docs-wrap class="diamond-spacing-bottom-lg"></docs-wrap>
 
 ## Fluid spacing between elements
 
 {['fluid-sm', 'fluid', 'fluid-lg'].map((size) => (
-  <docs-wrap class={`diamond-spacing-bottom-${size}`}>{size}</docs-wrap>
+  <>
+    <docs-wrap></docs-wrap>
+    <docs-spacing size={size} class={`diamond-spacing-bottom-${size}`}></docs-spacing>
+  </>
 ))}
 
-<docs-wrap class="diamond-spacing-bottom-lg">End element for demo purposes</docs-wrap>
+<docs-wrap class="diamond-spacing-bottom-lg"></docs-wrap>
 
+## Usage
+
+Generally, `md` is good for padding components and horizontal spacing between elements or vertical between similar elements. The default spacing `--diamond-spacing` is an alias of `--diamond-spacing-md`.
+
+<diamond-grid class="diamond-spacing-bottom-md" wrap="wrap">
+  {[0, 1, 2, 3].map(() => (
+    <diamond-grid-item small-mobile="12" large-mobile="6" large-tablet="3">
+      <diamond-card border>
+        <h3 class="sb-unstyled">Card title</h3>
+        <p class="sb-unstyled">
+          These cards use md padding within and have
+          a gap of md spacing between each card in the grid.
+        </p>
+      </diamond-card>
+    </diamond-grid-item>
+  ))}
+</diamond-grid>
+
+`Fluid` spacing varies depending on the browser size and is best used for spacing between large elements or padding within large sections of the page.
+
+<diamond-section padding="fluid" class="diamond-theme-medium">
+  <docs-spacing size="fluid" direction="top"></docs-spacing>
+  <diamond-wrap size="md" gutter="md">
+    <h3 class="sb-unstyled">Section title</h3>
+    <p class="sb-unstyled">
+      This section uses fluid spacing to create a natural feeling amount of spacing around
+      the content on any screen size.
+    </p>
+  </diamond-wrap>
+  <docs-spacing size="fluid"></docs-spacing>
+</diamond-section>
+
+Use `lg` for spacing between larger sections of content or for emphasis, such as before a button.
+
+<diamond-section padding="fluid" class="diamond-theme-medium">
+  <diamond-wrap size="md" gutter="md">
+    <h3 class="sb-unstyled">Section title</h3>
+    <p class="sb-unstyled diamond-spacing-bottom-lg">
+      This paragraph uses a large bottom spacing to give more emphasis to the CTA beneath.
+    </p>
+    <docs-spacing size="lg" direction="top" alignment="left"></docs-spacing>
+    <diamond-button>
+      <button type="button">Button text</button>
+    </diamond-button>
+  </diamond-wrap>
+
+</diamond-section>

--- a/docs/tokens/Spacing.mdx
+++ b/docs/tokens/Spacing.mdx
@@ -9,7 +9,7 @@ Generally, md is good for padding components and horizontal spacing between elem
 
 Use lg for spacing between larger sections of content or for emphasis, such as before a button.
 
-xl and fluid are great for spacign around large sections of content, such as page sections.
+xl and fluid are great for spacing around large sections of content, such as page sections.
 
 <Source code={code} language='css' />
 

--- a/docs/tokens/Spacing.mdx
+++ b/docs/tokens/Spacing.mdx
@@ -5,13 +5,15 @@ import code from '../../styles/tokens/spacing.css?inline';
 
 # Spacing
 
-Generally, md is good for padding components and horizontal spacing between elements or vertical between similar elements.
+The spacing tokens define a set of sizes used for creating space around or within elements, like margins and padding.
+
+Generally, md is good for padding components and horizontal spacing between elements or vertical between similar elements. The default spacing `--diamond-spacing` is an alias of `--diamond-spacing-md`.
 
 Use lg for spacing between larger sections of content or for emphasis, such as before a button.
 
 xl and fluid are great for spacing around large sections of content, such as page sections.
 
-<Source code={code} language='css' />
+<docs-token-table code={code}></docs-token-table>
 
 ## Fixed spacing between elements
 

--- a/docs/tokens/Theme.mdx
+++ b/docs/tokens/Theme.mdx
@@ -8,6 +8,6 @@ import * as ThemingStories from '../recipes/Theming.stories.ts'
 
 Themes allow customisation of a few key variables that can be consumed inside components.
 
-<Source code={code} language='css' />
+<docs-token-table code={code}></docs-token-table>
 
 <Canvas of={ThemingStories.Theming} />

--- a/docs/tokens/Transition.mdx
+++ b/docs/tokens/Transition.mdx
@@ -5,7 +5,7 @@ import code from '../../styles/tokens/transition.css?inline';
 
 # Transition
 
-<Source code={code} language='css' />
+<docs-token-table code={code}></docs-token-table>
 
 <diamond-grid wrap="wrap">
   <diamond-grid-item small-mobile="12" tablet="6" small-desktop="3">

--- a/docs/tokens/Wrap.mdx
+++ b/docs/tokens/Wrap.mdx
@@ -7,7 +7,7 @@ import code from '../../styles/tokens/wrap.css?inline';
 
 Wraps are used to constrain content to a max width.
 
-<Source code={code} language='css' />
+<docs-token-table code={code}></docs-token-table>
 
 {['xs', 'sm', 'md', 'lg', 'xl', 'xxl', 'xxxl', 'xxxxl'].map((size) => (
   <diamond-wrap size={size} class="diamond-spacing-bottom-md">

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@storybook/web-components-vite": "^8.0.9",
         "eslint": "^8.56.0",
         "eslint-plugin-lit-a11y": "^1.1.0-next.1",
+        "eslint-plugin-spellcheck": "0.0.20",
         "eslint-plugin-storybook": "^0.8.0",
         "glob": "^10.3.10",
         "husky": "^8.0.3",
@@ -10131,6 +10132,20 @@
         "safe-regex": "^2.1.1"
       }
     },
+    "node_modules/eslint-plugin-spellcheck": {
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-spellcheck/-/eslint-plugin-spellcheck-0.0.20.tgz",
+      "integrity": "sha512-GJa6vgzWAYqe0elKADAsiBRrhvqBnKyt7tpFSqlCZJsK2W9+K80oMyHhKolA7vJ13H5RCGs5/KCN+mKUyKoAiA==",
+      "dev": true,
+      "dependencies": {
+        "globals": "^13.0.0",
+        "hunspell-spellchecker": "^1.0.2",
+        "lodash": "^4.17.15"
+      },
+      "peerDependencies": {
+        "eslint": ">=0.8.0"
+      }
+    },
     "node_modules/eslint-plugin-storybook": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.8.0.tgz",
@@ -11962,6 +11977,15 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/hunspell-spellchecker": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hunspell-spellchecker/-/hunspell-spellchecker-1.0.2.tgz",
+      "integrity": "sha512-4DwmFAvlz+ChsqLDsZT2cwBsYNXh+oWboemxXtafwKIyItq52xfR4e4kr017sLAoPaSYVofSOvPUfmOAhXyYvw==",
+      "dev": true,
+      "bin": {
+        "hunspell-tojson": "bin/hunspell-tojson.js"
       }
     },
     "node_modules/husky": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@storybook/web-components-vite": "^8.0.9",
     "eslint": "^8.56.0",
     "eslint-plugin-lit-a11y": "^1.1.0-next.1",
+    "eslint-plugin-spellcheck": "0.0.20",
     "eslint-plugin-storybook": "^0.8.0",
     "glob": "^10.3.10",
     "husky": "^8.0.3",

--- a/styles/tokens/color.css
+++ b/styles/tokens/color.css
@@ -2,6 +2,7 @@
 ::backdrop {
   --diamond-color-white: #fff;
 
+  --diamond-color-grey-50: #f2f2f2;
   --diamond-color-grey-100: #e6e6e6;
   --diamond-color-grey-200: #ccc;
   --diamond-color-grey-300: #b3b3b3;

--- a/styles/tokens/spacing.css
+++ b/styles/tokens/spacing.css
@@ -1,7 +1,8 @@
 :root {
   --diamond-spacing-thumb: 2.625rem;
 
-  --diamond-spacing: 1rem;
+  --diamond-spacing-md: 1rem;
+  --diamond-spacing: var(--diamond-spacing-md);
   --diamond-spacing-xs: calc(var(--diamond-spacing) / 4);
   --diamond-spacing-sm: calc(var(--diamond-spacing) / 2);
   --diamond-spacing-lg: calc(var(--diamond-spacing) * 2);


### PR DESCRIPTION
Wrapped up a few related tickets in here:

- [Token examples are collapsed on live](https://linear.app/etch/issue/ETCH-757/token-code-examples-are-collapsed-on-live) and Carl suggested we could use tabled like Figma to display tokens so we have a token table component now.
- [Spacing tokens recommends a token size that doesn't exist](https://linear.app/etch/issue/ETCH-536/spacing-token-docs-recommend-md-size-that-doenst-exist)
- [Better spacing docs](https://linear.app/etch/issue/ETCH-545/better-spacing-docs)
- I've also added an eslint spellchecker

Most of the doc improvements are around the tokens docs, keeping the component docs pretty pure.

![localhost_6006_iframe html_viewMode=docs id=docs-tokens-spacing--docs args=](https://github.com/user-attachments/assets/705f67eb-82b7-4ea5-92a4-177e53b03556)
