### PR TITLE
docs: input button group select example, fix outline focus issue

### DIFF
--- a/components/composition/InputButtonGroup/InputButtonGroup.stories.ts
+++ b/components/composition/InputButtonGroup/InputButtonGroup.stories.ts
@@ -80,12 +80,21 @@ InputButtonGroupSelect.parameters = {
 export const InputButtonGroupSearch: StoryObj = {
   render: () => html`
     <diamond-input-button-group>
-        <diamond-input>
-          <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor">
-            <path d="M784-120 532-372q-30 24-69 38t-83 14q-109 0-184.5-75.5T120-580q0-109 75.5-184.5T380-840q109 0 184.5 75.5T640-580q0 44-14 83t-38 69l252 252-56 56ZM380-400q75 0 127.5-52.5T560-580q0-75-52.5-127.5T380-760q-75 0-127.5 52.5T200-580q0 75 52.5 127.5T380-400Z"/>
-          </svg>
-          <input value="" placeholder="Search..." />
-        </diamond-input>
+      <diamond-input>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          height="24px"
+          viewBox="0 -960 960 960"
+          width="24px"
+          fill="none"
+        >
+          <path
+            d="M784-120 532-372q-30 24-69 38t-83 14q-109 0-184.5-75.5T120-580q0-109 75.5-184.5T380-840q109 0 184.5 75.5T640-580q0 44-14 83t-38 69l252 252-56 56ZM380-400q75 0 127.5-52.5T560-580q0-75-52.5-127.5T380-760q-75 0-127.5 52.5T200-580q0 75 52.5 127.5T380-400Z"
+            fill="currentColor"
+          />
+        </svg>
+        <input value="" placeholder="Search..." />
+      </diamond-input>
       <diamond-button>
         <button type="button">Submit</button>
       </diamond-button>

--- a/components/composition/InputButtonGroup/InputButtonGroup.stories.ts
+++ b/components/composition/InputButtonGroup/InputButtonGroup.stories.ts
@@ -2,7 +2,7 @@ import { StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 
 export default {
-  component: 'diamond-inoput-button-group',
+  component: 'diamond-input-button-group',
 };
 
 export const InputButtonGroup: StoryObj = {
@@ -20,4 +20,50 @@ export const InputButtonGroup: StoryObj = {
       </diamond-button>
     </diamond-input-button-group>
   `,
+};
+
+InputButtonGroup.parameters = {
+  docs: {
+    description: {
+      story: 'A composition of an input and a button, styled to look like a single component.',
+    },
+  },
+};
+
+export const InputButtonGroupSelect: StoryObj = {
+  render: () => html`
+    <diamond-input-button-group>
+      <diamond-input>
+        <select>
+          <option value="1">Option 1</option>
+          <option value="2">Option 2</option>
+          <option value="3">Option 3</option>
+        </select>
+        <svg
+          fill="none"
+          viewBox="0 0 24 24"
+          height="24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            xmlns="http://www.w3.org/2000/svg"
+            d="M5.29289 9.29289C5.68342 8.90237 6.31658 8.90237 6.70711 9.29289L12 14.5858L17.2929 9.29289C17.6834 8.90237 18.3166 8.90237 18.7071 9.29289C19.0976 9.68342 19.0976 10.3166 18.7071 10.7071L12.7071 16.7071C12.3166 17.0976 11.6834 17.0976 11.2929 16.7071L5.29289 10.7071C4.90237 10.3166 4.90237 9.68342 5.29289 9.29289Z"
+            fill="currentColor"
+          ></path>
+        </svg>
+      </diamond-input>
+      <diamond-button>
+        <button type="button">Button</button>
+      </diamond-button>
+    </diamond-input-button-group>
+  `,
+};
+
+InputButtonGroupSelect.parameters = {
+  docs: {
+    description: {
+      story: 'The input button group can be used with any input type, including select elements.',
+    },
+  },
 };

--- a/components/composition/InputButtonGroup/InputButtonGroup.stories.ts
+++ b/components/composition/InputButtonGroup/InputButtonGroup.stories.ts
@@ -25,7 +25,8 @@ export const InputButtonGroup: StoryObj = {
 InputButtonGroup.parameters = {
   docs: {
     description: {
-      story: 'A composition of an input and a button, styled to look like a single component.',
+      story: `A composition of an input and a button, styled to look
+      like a single component.`,
     },
   },
 };
@@ -63,7 +64,8 @@ export const InputButtonGroupSelect: StoryObj = {
 InputButtonGroupSelect.parameters = {
   docs: {
     description: {
-      story: 'The input button group can be used with any input type, including select elements.',
+      story: `The input button group can be used with
+      any input type, including select elements.`,
     },
   },
 };

--- a/components/composition/InputButtonGroup/InputButtonGroup.stories.ts
+++ b/components/composition/InputButtonGroup/InputButtonGroup.stories.ts
@@ -3,6 +3,14 @@ import { html } from 'lit';
 
 export default {
   component: 'diamond-input-button-group',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'This composition allows for an input control to be paired with a button, handling scaling and alignment of both elements.',
+      },
+    },
+  },
 };
 
 export const InputButtonGroup: StoryObj = {
@@ -25,8 +33,7 @@ export const InputButtonGroup: StoryObj = {
 InputButtonGroup.parameters = {
   docs: {
     description: {
-      story: `A composition of an input and a button, styled to look
-      like a single component.`,
+      story: `A composition of an input and a button.`,
     },
   },
 };
@@ -68,4 +75,20 @@ InputButtonGroupSelect.parameters = {
       any input type, including select elements.`,
     },
   },
+};
+
+export const InputButtonGroupSearch: StoryObj = {
+  render: () => html`
+    <diamond-input-button-group>
+        <diamond-input>
+          <svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="currentColor">
+            <path d="M784-120 532-372q-30 24-69 38t-83 14q-109 0-184.5-75.5T120-580q0-109 75.5-184.5T380-840q109 0 184.5 75.5T640-580q0 44-14 83t-38 69l252 252-56 56ZM380-400q75 0 127.5-52.5T560-580q0-75-52.5-127.5T380-760q-75 0-127.5 52.5T200-580q0 75 52.5 127.5T380-400Z"/>
+          </svg>
+          <input value="" placeholder="Search..." />
+        </diamond-input>
+      <diamond-button>
+        <button type="button">Submit</button>
+      </diamond-button>
+    </diamond-input-button-group>
+  `,
 };

--- a/components/control/Button/Button.css
+++ b/components/control/Button/Button.css
@@ -56,6 +56,8 @@ diamond-button {
 
     &:not(:active):focus-visible {
       outline-offset: var(--diamond-button-outline-offset);
+      position: relative;
+      z-index: 1;
     }
   }
 

--- a/components/control/Button/Button.css
+++ b/components/control/Button/Button.css
@@ -57,6 +57,7 @@ diamond-button {
     &:not(:active):focus-visible {
       outline-offset: var(--diamond-button-outline-offset);
       position: relative;
+      /* This z-index prevents the focus outline from being clipped by the parent */
       z-index: 1;
     }
   }

--- a/components/control/Input/Input.css
+++ b/components/control/Input/Input.css
@@ -88,14 +88,11 @@ diamond-input {
 
   /* Prefix */
   &:has(* + :is(input, textarea, select)) > :first-child {
-    /* margin-right: calc(var(--diamond-input-padding-inline) / 2 * -1); */
     padding: 0 0 0 calc(var(--diamond-input-padding-inline) / 2);
   }
 
   /* Suffix */
   :is(input, textarea, select) + * {
-    /* margin-left: calc(var(--diamond-input-padding-inline) / 2 * -1); */
-    /* ^Find out what this does before removing it completely */
     padding: 0 calc(var(--diamond-input-padding-inline) / 2) 0 0;
   }
 }

--- a/components/control/Input/Input.css
+++ b/components/control/Input/Input.css
@@ -88,13 +88,14 @@ diamond-input {
 
   /* Prefix */
   &:has(* + :is(input, textarea, select)) > :first-child {
-    margin-right: calc(var(--diamond-input-padding-inline) / 2 * -1);
+    /* margin-right: calc(var(--diamond-input-padding-inline) / 2 * -1); */
     padding: 0 0 0 calc(var(--diamond-input-padding-inline) / 2);
   }
 
   /* Suffix */
   :is(input, textarea, select) + * {
-    margin-left: calc(var(--diamond-input-padding-inline) / 2 * -1);
+    /* margin-left: calc(var(--diamond-input-padding-inline) / 2 * -1); */
+    /* ^Find out what this does before removing it completely */
     padding: 0 calc(var(--diamond-input-padding-inline) / 2) 0 0;
   }
 }

--- a/components/control/Input/Input.css
+++ b/components/control/Input/Input.css
@@ -67,10 +67,10 @@ diamond-input {
   select {
     cursor: pointer;
     margin-right: calc(
-      var(--diamond-icon-size) * -1 - var(--diamond-input-padding-inline) * 0.5
+      var(--diamond-icon-size) * -1 - var(--diamond-input-padding-inline)
     );
     padding-right: calc(
-      var(--diamond-icon-size) + var(--diamond-input-padding-inline) * 1.5
+      var(--diamond-icon-size) + var(--diamond-input-padding-inline)
     );
   }
 
@@ -84,15 +84,21 @@ diamond-input {
     box-sizing: content-box;
     flex-shrink: 0;
     inline-size: var(--diamond-icon-size);
+    pointer-events: none;
   }
 
   /* Prefix */
   &:has(* + :is(input, textarea, select)) > :first-child {
+    margin-right: calc(var(--diamond-input-padding-inline) / 2 * -1);
     padding: 0 0 0 calc(var(--diamond-input-padding-inline) / 2);
   }
 
   /* Suffix */
   :is(input, textarea, select) + * {
-    padding: 0 calc(var(--diamond-input-padding-inline) / 2) 0 0;
+    padding: 0 calc(var(--diamond-input-padding-inline) / 2);
+  }
+
+  :is(input, textarea):has(+ *) {
+    padding-right: 0;
   }
 }


### PR DESCRIPTION
Fixed an issue where the focus outline on the button in the input button group was layered behind the input.

<img width="1004" alt="Screenshot 2024-08-21 at 14 26 23" src="https://github.com/user-attachments/assets/a793faa2-9705-43a8-874d-7762d890d0d9">

<img width="1004" alt="Screenshot 2024-08-21 at 14 27 12" src="https://github.com/user-attachments/assets/70a9187d-dea8-41d8-9e0b-d0636ce13646">


Fixed an issue in the input select where a margin applied to the suffix/prefix was distorting the focus outline:

<img width="1011" alt="Screenshot 2024-08-21 at 14 28 12" src="https://github.com/user-attachments/assets/69093c6c-a8de-42fa-bb82-05cab5945bc6">

<img width="1011" alt="Screenshot 2024-08-21 at 14 29 27" src="https://github.com/user-attachments/assets/fdf3a8b8-fbb8-4c61-8085-e826752710fa">

Added a new story for the input button group using a select type input:

<img width="1011" alt="Screenshot 2024-08-21 at 14 30 41" src="https://github.com/user-attachments/assets/739f9fad-231b-482e-b006-b65ffca62bd9">

